### PR TITLE
Add Ruby installation wrapper

### DIFF
--- a/shell/install.sh
+++ b/shell/install.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Each internal script manages its own shell options
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Source internal scripts
+source "$SCRIPT_DIR/internal/_install_prerequisite.sh" || {
+  echo "Failed to load prerequisite installer" >&2
+  exit 1
+}
+source "$SCRIPT_DIR/internal/_install_ruby.sh" || {
+  echo "Failed to load ruby installer" >&2
+  exit 1
+}
+
+# Run the installers
+install_prerequisite
+install_ruby
+


### PR DESCRIPTION
## Summary
- implement `shell/install.sh` that sources the internal prerequisite and ruby installers to install Ruby
- remove redundant `set -euo pipefail` since internals configure their own shell options

## Testing
- `bash -n shell/install.sh`
- `bats shell/test/*` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840cffc1154832b935a68b36f173b28