### PR TITLE
Add rollback support to Ruby zsh installers

### DIFF
--- a/ruby/install_zsh.rb
+++ b/ruby/install_zsh.rb
@@ -1,0 +1,37 @@
+require_relative 'installers/zsh_binary_installer'
+require_relative 'installers/oh_my_zsh_installer'
+require_relative 'installers/powerlevel10k_installer'
+require_relative 'installers/zgenom_installer'
+
+installers = [
+  ZshBinaryInstaller.new,
+  OhMyZshInstaller.new,
+  Powerlevel10kInstaller.new,
+  ZgenomInstaller.new
+]
+
+action = ARGV[0] || 'install'
+
+case action
+when 'install'
+  completed = []
+  installers.each do |inst|
+    begin
+      if inst.installed?
+        puts "#{inst.class.name} already installed"
+      else
+        inst.install
+        completed << inst
+      end
+    rescue StandardError => e
+      warn "Error installing #{inst.class.name}: #{e}"
+      completed.reverse_each { |i| i.rollback }
+      exit 1
+    end
+  end
+when 'rollback'
+  installers.reverse_each(&:rollback)
+else
+  puts "Unknown action: #{action}"
+  puts "Usage: #{File.basename($0)} [install|rollback]"
+end

--- a/ruby/installers/base.rb
+++ b/ruby/installers/base.rb
@@ -1,0 +1,13 @@
+class Installer
+  def installed?
+    raise NotImplementedError
+  end
+
+  def install
+    raise NotImplementedError
+  end
+
+  def rollback
+    raise NotImplementedError
+  end
+end

--- a/ruby/installers/oh_my_zsh_installer.rb
+++ b/ruby/installers/oh_my_zsh_installer.rb
@@ -1,0 +1,16 @@
+require 'fileutils'
+require_relative 'base'
+
+class OhMyZshInstaller < Installer
+  def installed?
+    Dir.exist?(File.expand_path('~/.oh-my-zsh'))
+  end
+
+  def install
+    system(%(sh -c "$(curl -fsSL https://raw.github.com/ohmyzsh/ohmyzsh/master/tools/install.sh)"))
+  end
+
+  def rollback
+    FileUtils.rm_rf(File.expand_path('~/.oh-my-zsh'))
+  end
+end

--- a/ruby/installers/powerlevel10k_installer.rb
+++ b/ruby/installers/powerlevel10k_installer.rb
@@ -1,0 +1,68 @@
+require 'fileutils'
+require_relative 'base'
+
+class Powerlevel10kInstaller < Installer
+  def installed?
+    Dir.exist?(File.expand_path('~/.oh-my-zsh/custom/themes/powerlevel10k'))
+  end
+
+  def install
+    dest = File.expand_path('~/.oh-my-zsh/custom/themes/powerlevel10k')
+    system("git clone https://github.com/romkatv/powerlevel10k.git #{dest}") unless installed?
+
+    zshrc = File.expand_path('~/.zshrc')
+    if File.exist?(zshrc)
+      content = File.read(zshrc)
+      if content =~ /^ZSH_THEME=/
+        content.sub!(/^ZSH_THEME=.*/, 'ZSH_THEME="powerlevel10k/powerlevel10k"')
+        File.write(zshrc, content)
+      end
+      lines = File.readlines(zshrc)
+      unless lines.any? { |l| l =~ /^# Enable Powerlevel10k/ }
+        addition = [
+          "# Enable Powerlevel10k instant prompt. Should stay close to the top of ~/.zshrc.",
+          "# Initialization code that may require console input (password prompts, [y/n]",
+          "# confirmations, etc.) must go above this block; everything else may go below.",
+          "if [[ -r \"${XDG_CACHE_HOME:-$HOME/.cache}/p10k-instant-prompt-${(%):-%n}.zsh\" ]]; then",
+          "    source \"${XDG_CACHE_HOME:-$HOME/.cache}/p10k-instant-prompt-${(%):-%n}.zsh\"",
+          "fi"
+        ]
+        File.open(zshrc, 'a') { |f| addition.each { |l| f.puts l } }
+      end
+      unless lines.any? { |l| l =~ /^# To customize prompt/ }
+        File.open(zshrc, 'a') do |f|
+          f.puts "# To customize prompt, run `p10k configure` or edit ~/.p10k.zsh."
+          f.puts "[[ ! -f ~/.p10k.zsh ]] || source ~/.p10k.zsh"
+        end
+      end
+    end
+
+    local_p10k = File.join(File.dirname(__FILE__), '..', '.p10k.zsh')
+    if File.exist?(local_p10k)
+      FileUtils.ln_sf(local_p10k, File.expand_path('~/.p10k.zsh'))
+    end
+  end
+
+  def rollback
+    dest = File.expand_path('~/.oh-my-zsh/custom/themes/powerlevel10k')
+    FileUtils.rm_rf(dest)
+
+    zshrc = File.expand_path('~/.zshrc')
+    if File.exist?(zshrc)
+      content = File.read(zshrc)
+      content.gsub!(/^ZSH_THEME="powerlevel10k\/powerlevel10k"/, 'ZSH_THEME="robbyrussell"')
+      lines = content.lines.reject do |l|
+        l =~ /^# Enable Powerlevel10k/ ||
+        l.include?('p10k-instant-prompt') ||
+        l =~ /^# Initialization code/ ||
+        l =~ /^# confirmations/ ||
+        l =~ /^# To customize prompt/ ||
+        l.include?('p10k.zsh')
+      end
+      File.write(zshrc, lines.join)
+    end
+
+    p10k_link = File.expand_path('~/.p10k.zsh')
+    FileUtils.rm_f(p10k_link) if File.symlink?(p10k_link)
+  end
+end

--- a/ruby/installers/zgenom_installer.rb
+++ b/ruby/installers/zgenom_installer.rb
@@ -1,0 +1,34 @@
+require 'fileutils'
+require_relative 'base'
+
+class ZgenomInstaller < Installer
+  def installed?
+    Dir.exist?(File.expand_path('~/.zgenom'))
+  end
+
+  def install
+    dest = File.expand_path('~/.zgenom')
+    system("git clone https://github.com/jandamm/zgenom.git #{dest}") unless installed?
+    zshrc = File.expand_path('~/.zshrc')
+    lines = File.exist?(zshrc) ? File.readlines(zshrc) : []
+    unless lines.any? { |l| l =~ /^# load zgenom/ }
+      File.open(zshrc, 'a') do |f|
+        f.puts '# load zgenom'
+        f.puts "[[ ! -f #{dest}/zgenom.zsh ]] || source \"#{dest}/zgenom.zsh\""
+      end
+    end
+  end
+
+  def rollback
+    dest = File.expand_path('~/.zgenom')
+    FileUtils.rm_rf(dest)
+
+    zshrc = File.expand_path('~/.zshrc')
+    if File.exist?(zshrc)
+      lines = File.readlines(zshrc).reject do |l|
+        l =~ /^# load zgenom/ || l.include?("#{dest}/zgenom.zsh")
+      end
+      File.write(zshrc, lines.join)
+    end
+  end
+end

--- a/ruby/installers/zsh_binary_installer.rb
+++ b/ruby/installers/zsh_binary_installer.rb
@@ -1,0 +1,16 @@
+require 'fileutils'
+require_relative 'base'
+
+class ZshBinaryInstaller < Installer
+  def installed?
+    File.exist?(File.expand_path('~/.local/bin/zsh'))
+  end
+
+  def install
+    system(%(sh -c "$(curl -fsSL https://raw.githubusercontent.com/romkatv/zsh-bin/master/install)"))
+  end
+
+  def rollback
+    FileUtils.rm_f(File.expand_path('~/.local/bin/zsh'))
+  end
+end


### PR DESCRIPTION
## Summary
- add `rollback` method to installer base
- implement rollback steps for zsh, oh-my-zsh, powerlevel10k and zgenom
- enhance `install_zsh.rb` with install/rollback logic

## Testing
- `ruby -c ruby/install_zsh.rb`
- `ruby -c ruby/installers/base.rb`
- `ruby -c ruby/installers/zsh_binary_installer.rb`
- `ruby -c ruby/installers/oh_my_zsh_installer.rb`
- `ruby -c ruby/installers/powerlevel10k_installer.rb`
- `ruby -c ruby/installers/zgenom_installer.rb`


------
https://chatgpt.com/codex/tasks/task_e_684b6e5b505c832b82d0d7ebbf7d04e1