### PR TITLE
Add mocks for CurlComponent tests

### DIFF
--- a/ruby/spec/lib/components/fetch/curl_spec.rb
+++ b/ruby/spec/lib/components/fetch/curl_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+require 'components/fetch/curl'
+
+RSpec.describe Component::CurlComponent do
+  subject(:curl) { described_class.new }
+
+  describe '#exists?' do
+    it 'returns true when curl command is available' do
+      allow(curl).to receive(:system)
+        .with('curl', '--version', out: File::NULL, err: File::NULL)
+        .and_return(true)
+
+      expect(curl.exists?).to be true
+    end
+
+    it 'returns false when curl command is missing' do
+      allow(curl).to receive(:system)
+        .with('curl', '--version', out: File::NULL, err: File::NULL)
+        .and_return(false)
+
+      expect(curl.exists?).to be false
+    end
+  end
+
+  describe '#version' do
+    it 'returns the installed curl version' do
+      allow(curl).to receive(:`).with('curl --version 2>&1').and_return("curl 8.0.0 (x86_64-pc-linux-gnu)\n")
+      system('true') # ensure $CHILD_STATUS is successful
+
+      expect(curl.version).to eq('8.0.0')
+    end
+
+    it 'returns nil when curl is not installed' do
+      allow(curl).to receive(:`).with('curl --version 2>&1').and_raise(Errno::ENOENT)
+
+      expect(curl.version).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- mock `system` and backticks in `curl_spec` to verify `exists?` and `version`

## Testing
- `bundle exec rspec spec/lib/components/fetch/curl_spec.rb -fd` *(fails: bundler: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852d4661ef4832bb959aae1ae5a3a4b